### PR TITLE
Remove `enum34` from requirements

### DIFF
--- a/requirements_py3.txt
+++ b/requirements_py3.txt
@@ -1,4 +1,4 @@
 coverage
 codecov
 MonthDelta==1.0b0
-enum34
+enum34; python_version < '3.4'


### PR DESCRIPTION
You don't need `enum34` for Python 3.4+

Keeping it can mess with Python 3.6. Ref: https://stackoverflow.com/questions/48091332